### PR TITLE
Fix compile failure on GHC 7.10.

### DIFF
--- a/AhoCorasick.cabal
+++ b/AhoCorasick.cabal
@@ -35,6 +35,8 @@ library
     ,array
     ,mtl
 
+  ghc-options:      -Wall
+
 source-repository head
   type:     git
   location: http://github.com/lymar/AhoCorasick

--- a/Text/AhoCorasick.hs
+++ b/Text/AhoCorasick.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE RankNTypes, ScopedTypeVariables, ExistentialQuantification #-}
--- Module:      Text.Hastache
+{-# LANGUAGE RankNTypes, ScopedTypeVariables, ExistentialQuantification,
+    FlexibleContexts #-}
+
+-- Module:      Text.AhoCorasick
 -- Copyright:   Sergey S Lymar (c) 2012
 -- License:     BSD3
 -- Maintainer:  Sergey S Lymar <sergey.lymar@gmail.com>
@@ -78,7 +80,7 @@ import qualified Data.HashMap.Strict as M
 
 import Text.AhoCorasick.Internal.Deque (mkDQ, pushBack, popFront, dqLength, DQ)
 
-data (Eq keySymb, Hashable keySymb) => TNode keySymb s = 
+data (Eq keySymb, Hashable keySymb) => TNode keySymb s =
     TNode {
           tnId          :: Int
         , tnLinks       :: M.HashMap keySymb (STRef s (TNode keySymb s))
@@ -88,7 +90,7 @@ data (Eq keySymb, Hashable keySymb) => TNode keySymb s =
 
 type KeyLength = Int
 
-data (Eq keySymb, Hashable keySymb) => TTree keySymb val s = 
+data (Eq keySymb, Hashable keySymb) => TTree keySymb val s =
     TTree {
           ttRoot        :: STRef s (TNode keySymb s)
         , ttLastId      :: STRef s Int
@@ -97,21 +99,21 @@ data (Eq keySymb, Hashable keySymb) => TTree keySymb val s =
 
 type NodeIndex = Int
 
-data (Eq keySymb, Hashable keySymb) => SMElem keySymb = 
+data (Eq keySymb, Hashable keySymb) => SMElem keySymb =
     SMElem {
           smeLinks      :: M.HashMap keySymb NodeIndex
         , smeFail       :: NodeIndex
         , smeValuesIds  :: [Int]
     }
-    
-data (Eq keySymb, Hashable keySymb) => StateMachine keySymb val = 
+
+data (Eq keySymb, Hashable keySymb) => StateMachine keySymb val =
     StateMachine {
           smStates      :: Array NodeIndex (SMElem keySymb)
         , smValues      :: Array Int (KeyLength, val)
         , smState       :: Int
     }
 
-data (Eq keySymb, Hashable keySymb) => SMStepRes keySymb val = 
+data (Eq keySymb, Hashable keySymb) => SMStepRes keySymb val =
     SMStepRes {
           smsrMatch     :: [(KeyLength, val)]
         , smsrNextSM    :: StateMachine keySymb val
@@ -124,18 +126,18 @@ data Position val =
         , pVal          :: val
     }
 
-instance (Eq keySymb, Hashable keySymb, Show keySymb) => 
+instance (Eq keySymb, Hashable keySymb, Show keySymb) =>
                                                     Show (SMElem keySymb) where
     show (SMElem l f v) = concat ["SMElem {smeLinks = ", show l,
         ", smeFail = ", show f,", smeValuesIds = ", show v, "}"]
 
-instance (Eq keySymb, Hashable keySymb, Show keySymb, Show val) => 
+instance (Eq keySymb, Hashable keySymb, Show keySymb, Show val) =>
                                         Show (StateMachine keySymb val) where
     show (StateMachine st vals state) = concat [
         "StateMachine {smStates = ", show st,
         ", smValues = ", show vals, ", smState = ", show state,"}"]
 
-instance (Eq keySymb, Hashable keySymb, Show keySymb, Show val) => 
+instance (Eq keySymb, Hashable keySymb, Show keySymb, Show val) =>
                                             Show (SMStepRes keySymb val) where
     show (SMStepRes f n) = concat [
         "StateMachineStepRes {smsrFound = ", show f,
@@ -159,8 +161,8 @@ initNewTTree = do
     lid <- newSTRef rootNodeId
     kw <- mkDQ
     return $ TTree root lid kw
-    
-mkNewTNode :: (Eq keySymb, Hashable keySymb) => 
+
+mkNewTNode :: (Eq keySymb, Hashable keySymb) =>
     TTree keySymb a s -> ST s (TNode keySymb s)
 mkNewTNode tree = do
     modifySTRef lid (+1)
@@ -169,7 +171,7 @@ mkNewTNode tree = do
     where
     lid = ttLastId tree
 
-addKeyVal :: forall val s keySymb. (Eq keySymb, Hashable keySymb) => 
+addKeyVal :: forall val s keySymb. (Eq keySymb, Hashable keySymb) =>
     TTree keySymb val s -> [keySymb] -> val -> ST s ()
 addKeyVal tree key val = addSymb (ttRoot tree) key
     where
@@ -210,7 +212,7 @@ findFailures tree = do
             pushBack dq link
             fRef <- findParentFail link (tnFail node) symb
             f <- readSTRef fRef
-            modifySTRef link (\n -> n {tnFail = Just fRef, 
+            modifySTRef link (\n -> n {tnFail = Just fRef,
                 tnValuesIds = (tnValuesIds n) ++ (tnValuesIds f)})
             ) $ tnLinks node ~> M.toList
         return ()
@@ -223,19 +225,19 @@ findFailures tree = do
             (Nothing, True) -> return root
             _ -> findParentFail link (tnFail cf) symb
 
-convertToStateMachine :: forall val s keySymb. (Eq keySymb, Hashable keySymb) => 
-    TTree keySymb val s -> 
+convertToStateMachine :: forall val s keySymb. (Eq keySymb, Hashable keySymb) =>
+    TTree keySymb val s ->
     ST s (StateMachine keySymb val)
 convertToStateMachine tree = do
     size <- readSTRef $ ttLastId tree
     nds <- execStateT (convertNode $ ttRoot tree) []
-    
+
     vlsSize <- dqLength $ ttValues tree
     vls <- mapM (\i -> do
         k <- popFront (ttValues tree)
         return (i,fromJust k)
         ) [0..(vlsSize-1)]
-    
+
     StateMachine (array (0, size) nds) (array (0, vlsSize-1) vls) rootNodeId
         ~> return
     where
@@ -258,11 +260,11 @@ convertToStateMachine tree = do
             ) $ M.toList lnksMap
         return $ M.fromList nl
 
-resetStateMachine :: (Eq keySymb, Hashable keySymb) => 
+resetStateMachine :: (Eq keySymb, Hashable keySymb) =>
     StateMachine keySymb val -> StateMachine keySymb val
 resetStateMachine m = m { smState = rootNodeId }
 
-stateMachineStep :: (Eq keySymb, Hashable keySymb) => 
+stateMachineStep :: (Eq keySymb, Hashable keySymb) =>
     StateMachine keySymb val -> keySymb -> SMStepRes keySymb val
 stateMachineStep sm symb =
     case (M.lookup symb links, currentState == rootNodeId) of
@@ -270,26 +272,26 @@ stateMachineStep sm symb =
             ((smStates sm) ! nextState ~> smeValuesIds ~> convertToVals)
             (sm { smState = nextState })
         (Nothing, True) -> SMStepRes [] sm
-        (Nothing, False) -> stateMachineStep 
-            (sm { smState = smeFail currentNode}) symb            
+        (Nothing, False) -> stateMachineStep
+            (sm { smState = smeFail currentNode}) symb
     where
     currentState = smState sm
     currentNode = (smStates sm) ! currentState
     links = smeLinks currentNode
     convertToVals idx = map (\i -> smValues sm ! i) idx
 
-findAll :: (Eq keySymb, Hashable keySymb) => 
+findAll :: (Eq keySymb, Hashable keySymb) =>
     StateMachine keySymb val -> [keySymb] -> [Position val]
-findAll sm str = 
+findAll sm str =
     step (resetStateMachine sm) (zip [0..] str) ~> concat
     where
     step _ [] = []
     step csm ((idx,symb):next) = case stateMachineStep csm symb of
         SMStepRes [] newsm -> step newsm next
-        SMStepRes r newsm -> (map (cnvToPos idx) r) : (step newsm next)      
+        SMStepRes r newsm -> (map (cnvToPos idx) r) : (step newsm next)
     cnvToPos idx (keyLength, val) = Position (idx - keyLength + 1) keyLength val
 
-makeSimpleStateMachine :: (Eq keySymb, Hashable keySymb) => 
+makeSimpleStateMachine :: (Eq keySymb, Hashable keySymb) =>
     [[keySymb]] -> StateMachine keySymb [keySymb]
 makeSimpleStateMachine keys = runST $ do
     tree <- initNewTTree
@@ -297,11 +299,10 @@ makeSimpleStateMachine keys = runST $ do
     findFailures tree
     convertToStateMachine tree
 
-makeStateMachine :: (Eq keySymb, Hashable keySymb) => 
+makeStateMachine :: (Eq keySymb, Hashable keySymb) =>
     [([keySymb], val)] -> StateMachine keySymb val
 makeStateMachine kv = runST $ do
     tree <- initNewTTree
     mapM_ (\(s,v) -> addKeyVal tree s v) kv
     findFailures tree
     convertToStateMachine tree
-


### PR DESCRIPTION
On GHC 7.10, this library won't build with -Wall without enabling
this directive. 

This is the error that I get before this commit:

```
[2 of 2] Compiling Text.AhoCorasick ( Text/AhoCorasick.hs, dist/dist-sandbox-113eb875/build/Text/AhoCorasick.o )

Text/AhoCorasick.hs:242:5:
    Non type-variable argument
      in the constraint: Control.Monad.State.Class.MonadState
                           [(Int, SMElem keySymb)] (t (ST s))
    (Use FlexibleContexts to permit this)
    When checking that ‘convertNode’ has the inferred type
      convertNode :: forall (t :: (* -> *) -> * -> *).
                     (transformers-0.4.2.0:Control.Monad.Trans.Class.MonadTrans t,
                      Control.Monad.State.Class.MonadState
                        [(Int, SMElem keySymb)] (t (ST s))) =>
                     STRef s (TNode keySymb s) -> t (ST s) ()
    In an equation for ‘convertToStateMachine’:
        convertToStateMachine tree
          = do { size <- readSTRef $ ttLastId tree;
                 nds <- execStateT (convertNode $ ttRoot tree) [];
                 vlsSize <- dqLength $ ttValues tree;
                 .... }
          where
              convertNode node
                = do { (n, l, fail) <- lift $ ...;
                       .... }
              convertLinks ::
                M.HashMap keySymb (STRef s (TNode keySymb s))
                -> ST s (M.HashMap keySymb Int)
              convertLinks lnksMap
                = do { nl <- mapM (\ (symb, link) -> ...) $ M.toList lnksMap;
                       .... }
```
